### PR TITLE
template::configuration.yml.erb: remove '+'

### DIFF
--- a/templates/configuration.yml.erb
+++ b/templates/configuration.yml.erb
@@ -13,7 +13,7 @@ default:
       enable_starttls_auto: true
 <% else -%>
       enable_starttls_auto: false
-+<% end -%>
+<% end -%>
 
 <% scope.lookupvar('redmine::override_options').keys.sort.each do |key| -%>
   <%= key %>: <%= scope.lookupvar('redmine::override_options')[key] %>


### PR DESCRIPTION
Un typo était présent dans ton fichier. il bloquait l'exécution du serveur apache